### PR TITLE
refactored D3 graph

### DIFF
--- a/lib/d3display.js
+++ b/lib/d3display.js
@@ -28,19 +28,35 @@ export default class D3Display {
       props: { data, width, height },
     } = this;
     const keysToString = {
-      0: 'c',
-      1: 'c#',
-      2: 'd',
-      3: 'd#',
-      4: 'e',
-      5: 'f',
-      6: 'f#',
-      7: 'g',
-      8: 'g#',
-      9: 'a',
-      10: 'a#',
-      11: 'b',
+      8: 'c',
+      3: 'c#',
+      10: 'd',
+      5: 'd#',
+      0: 'e',
+      7: 'f',
+      2: 'f#',
+      9: 'g',
+      4: 'g#',
+      11: 'a',
+      6: 'a#',
+      1: 'b',
     };
+
+    const apiNotesToWheelNotes = {
+      0: 8,
+      1: 3,
+      2: 10,
+      3: 5,
+      4: 0,
+      5: 7,
+      6: 2,
+      7: 9,
+      8: 4,
+      9: 11,
+      10: 6,
+      11: 1,
+    };
+
     console.log('data pulled into d3 from graph ->', data);
     let radius = 200;
     let maxValue = 200;
@@ -150,7 +166,7 @@ export default class D3Display {
     // songPositions are the dots on the board
     let songPositions = g
       .selectAll('.songPositions')
-      .data(data.filter((el, i) => i <= 20))
+      .data(data.filter((el, i) => i <= 20 && el.mode === 1)) // currently selecting less than 20 songs in DB and only songs in Major Keys
       .join('g')
       .attr('class', '.songPositions');
     songPositions
@@ -158,11 +174,18 @@ export default class D3Display {
       .attr('class', 'radarCircle')
       .attr('r', 4)
       .attr('cx', function (d, i) {
-        console.log('circle position x index', i);
-        return rScale(d.tempo) * Math.cos(angleSlice * i - Math.PI / 2);
+        console.log('circle position x mode minor, key number -->', d.key);
+        console.log('data', d);
+        return (
+          rScale(d.tempo) *
+          Math.cos(angleSlice * apiNotesToWheelNotes[d.key] - Math.PI / 2)
+        );
       })
       .attr('cy', function (d, i) {
-        return rScale(d.tempo) * Math.sin(angleSlice * i - Math.PI / 2);
+        return (
+          rScale(d.tempo) *
+          Math.sin(angleSlice * apiNotesToWheelNotes[d.key] - Math.PI / 2)
+        );
       })
       .style('fill', '#360071')
       .style('fill-opacity', 0.8);
@@ -175,10 +198,16 @@ export default class D3Display {
       .attr('dy', '1em')
       .attr('dx', '1em')
       .attr('x', function (d, i) {
-        return rScale(d.tempo) * Math.cos(angleSlice * i - Math.PI / 2);
+        return (
+          rScale(d.tempo) *
+          Math.cos(angleSlice * apiNotesToWheelNotes[d.key] - Math.PI / 2)
+        );
       })
       .attr('y', function (d, i) {
-        return rScale(d.tempo) * Math.sin(angleSlice * i - Math.PI / 2);
+        return (
+          rScale(d.tempo) *
+          Math.sin(angleSlice * apiNotesToWheelNotes[d.key] - Math.PI / 2)
+        );
       })
       .text((d) => `${d.name} - ${d.artists}`)
       .call(wrap, 60);


### PR DESCRIPTION

## Description:
- refactored D3 graph to reflect camelot wheel and only selecting songs in major keys only
## Changes I Made:
- changed position of string keys on axis lines to refelect camelot wheel
- filtered songs by major key and only selected 20 songs
- mapped keys to reposition songs to work with camelot wheel
## How to Test:
- in terminal, type npm install, then npm run build, then npm run dev in terminal